### PR TITLE
Links in js source are accidentally followed

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function touch (_url, opts, cb) {
     }
     opts.ee.emit('resp', resp, _url)
     if (resp.statusCode !== 200) return cb(new Error('statusCode is not 200. received '+resp.statusCode+' in '+_url ))
-    if (resp.headers['content-type'].indexOf('text/html') !== 1) {
+    if (resp.headers['content-type'].indexOf('text/html') !== -1) {
       var $ = cheerio.load(body)
         , links = []
         ;

--- a/tests/test-links-in-js.js
+++ b/tests/test-links-in-js.js
@@ -1,0 +1,35 @@
+var webtouch = require('../')
+, ok = require('okdone')
+, cleanup = require('cleanup')
+, http = require('http')
+, assert = require('assert')
+;
+
+var d = cleanup(function (error) {
+  if (error) process.exit(1)
+  ok.done()
+  process.exit()
+})
+
+// touch a .js file that has html source in it.
+// For the test to pass, webtouch needs to ignore links found in js files.
+var source = "var a = 'foo', b = '<img src=\"http://' + a + '.com/someimage.png\">'"
+ok.expect(1)
+
+http.createServer(function (req, resp) {
+  resp.statusCode = 200
+  if (req.url === '/js.js') {
+    resp.setHeader('content-type', 'text/javascript')
+    resp.end(source)
+  }
+  resp.statusCode = 404
+  resp.end()
+}).listen(8080, function () {
+  webtouch('http://localhost:8080/js.js', function (e, urls) {
+    if (e) throw e
+    assert.equal(urls.length, 1)
+    ok('no links followed in js')
+    d.cleanup()
+  });
+});
+


### PR DESCRIPTION
Spotted a typo causing cheerio to load non-html files and check for links.
